### PR TITLE
Add regex option to split tool.

### DIFF
--- a/PinnyNotes.WpfUi/Tools/SplitTool.cs
+++ b/PinnyNotes.WpfUi/Tools/SplitTool.cs
@@ -1,4 +1,6 @@
-﻿using PinnyNotes.Core.Enums;
+﻿using System.Text.RegularExpressions;
+
+using PinnyNotes.Core.Enums;
 using PinnyNotes.WpfUi.Commands;
 using PinnyNotes.WpfUi.Controls;
 
@@ -11,7 +13,8 @@ public class SplitTool : BaseTool, ITool
         SplitComma,
         SplitSpace,
         SplitTab,
-        SplitSelected
+        SplitSelected,
+        SplitSelectedRegex
     }
 
     private string? _selectedText = null;
@@ -25,7 +28,8 @@ public class SplitTool : BaseTool, ITool
                 new ToolMenuAction("Space", new RelayCommand(() => MenuAction(ToolActions.SplitSpace))),
                 new ToolMenuAction("Tab", new RelayCommand(() => MenuAction(ToolActions.SplitTab))),
                 new ToolMenuAction("-"),
-                new ToolMenuAction("Selected", new RelayCommand(() => MenuAction(ToolActions.SplitSelected)))
+                new ToolMenuAction("Selected", new RelayCommand(() => MenuAction(ToolActions.SplitSelected))),
+                new ToolMenuAction("Selected (Regex)", new RelayCommand(() => MenuAction(ToolActions.SplitSelectedRegex)))
             ]
         );
     }
@@ -34,7 +38,7 @@ public class SplitTool : BaseTool, ITool
 
     private void MenuAction(ToolActions action)
     {
-        if (action != ToolActions.SplitSelected)
+        if (action != ToolActions.SplitSelected && action != ToolActions.SplitSelectedRegex)
         {
             _selectedText = null;
         }
@@ -60,6 +64,23 @@ public class SplitTool : BaseTool, ITool
             case ToolActions.SplitSelected:
                 if (!string.IsNullOrEmpty(_selectedText))
                     return text.Replace(_selectedText, Environment.NewLine);
+                break;
+            case ToolActions.SplitSelectedRegex:
+                if (!string.IsNullOrEmpty(_selectedText))
+                {
+                    try
+                    {
+                        return Regex.Replace(text, _selectedText, Environment.NewLine, RegexOptions.None, TimeSpan.FromSeconds(1));
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Leave text unchanged if selection is not a valid pattern.
+                    }
+                    catch (RegexMatchTimeoutException)
+                    {
+                        // Leave text unchanged if pattern takes too long to match.
+                    }
+                }
                 break;
         }
 


### PR DESCRIPTION
## What this does

A small step toward the "should support regular expressions" line in TODO.md: adds a **Selected (Regex)** action to the Split tool, next to the existing **Selected** action.

Select a pattern in the note (e.g. `\d+` or ` *[,;] *`), right-click → Split → Selected (Regex), and the text is split into lines on every match of that pattern.

It mirrors the existing `SplitSelected` flow exactly — captures `SelectedText`, clears the selection, applies via `ApplyFunctionToNoteText` — with the replacement done by `Regex.Replace(text, pattern, Environment.NewLine)` instead of `string.Replace`. Two guards on top, since the pattern is user input:

- An invalid pattern (`ArgumentException`) leaves the text unchanged instead of crashing.
- A 1-second match timeout (`RegexMatchTimeoutException`) leaves the text unchanged instead of freezing the UI thread on a catastrophic-backtracking pattern like `(a+)+$`.

No new UI or dialogs — consistent with how every other tool action works.

## Why this shape

The tools system is deliberately parameterless (menu actions operating on the note/selection), and the app has no text-input dialog convention to build on, so the selection doubles as the pattern. If you'd prefer a proper Search & Replace window with regex support (the fuller version of the TODO item), I'd be happy to take that on as a follow-up — this PR doesn't presuppose any design for it.

## Verification

- `dotnet build PinnyNotes.sln` — clean (only the pre-existing CS0162 warnings in App.xaml.cs).
- Drove the compiled `ModifyTextCallback` directly with a small test harness against the built assembly. All cases pass:
  - `\d+` on `a1b22c333d` → `a / b / c / d` (one per line)
  - ` *[,;] *` on `one, two ;three` → `one / two / three`
  - a plain word as pattern produces the same output as the existing "Selected" action
  - invalid pattern `(` → text unchanged
  - empty selection → text unchanged
  - existing "Selected" and comma splits unchanged (regression)
  - `(a+)+$` against 40 `a`s + `!` → returns unchanged after ~1 s (timeout fires, no UI hang)
